### PR TITLE
better diag for does_not_contain_ok

### DIFF
--- a/lib/Log/Any/Adapter/Test.pm
+++ b/lib/Log/Any/Adapter/Test.pm
@@ -116,7 +116,7 @@ sub does_not_contain_ok {
       _first_index( sub { $_->{message} =~ /$regex/ }, @{ $self->msgs } );
     if ( $found != -1 ) {
         $tb->ok( 0, $test_name );
-        $tb->diag( "found message matching $regex: " . $self->msgs->[$found] );
+        $tb->diag( "found message matching $regex: " . $self->msgs->[$found]->{message} );
     }
     else {
         $tb->ok( 1, $test_name );


### PR DESCRIPTION
Have does_not_contain_ok provide a useful diag on failure by reporting the relevant message, e.g.
# Failed test 'log does not contain '(?^:FIXME)''
# at ...
# found message matching (?^:FIXME): FIXME: use a smarter alg here

instead of
# Failed test 'log does not contain '(?^:FIXME)''
# at ...
# found message matching (?^:FIXME): HASH(0x2ed437c)
